### PR TITLE
[#11] As a developer, I can see the document of NimbleLocalAuthentication

### DIFF
--- a/NimbleLocalAuthentication.podspec
+++ b/NimbleLocalAuthentication.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/nimblehq/local-authentication-ios.git', :tag => s.version.to_s }
   s.ios.deployment_target = '11.0'
   s.source_files = 'Sources/Classes/**/*'
+  s.swift_version = '5.0'
   s.framework = 'LocalAuthentication'
   s.dependency 'KeychainAccess'
 end

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 # NimbleLocalAuthentication 1.0.0
 
-![build](https://github.com/nimblehq/local-authentication-ios/workflows/Tests/badge.svg?branch=develop)
+![Tests](https://github.com/nimblehq/local-authentication-ios/workflows/Tests/badge.svg?branch=develop)
 
 The basic idea of NimbleLocalAuthentication is that we want to wrap the LocalAuthentication framework. Developer can easily authenticate users biometrically or with a passphrase.
 
 Some awesome features of NimbleLocalAuthentication:
 
 - Support enable or disable the biometric feature on the application.
-- Easy to localized strings with biometric screens.
+- Easy to localized strings on biometric screens.
 
 You can check out more about the SDK in the document [WIP]
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# NimbleLocalAuthentication
+<p align="center">
+  <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png" />
+</p>
+
+---
+
+# NimbleLocalAuthentication 1.0.0
+
+![build](https://github.com/nimblehq/local-authentication-ios/workflows/Tests/badge.svg?branch=develop)
+
+The basic idea of NimbleLocalAuthentication is that we want to wrap the LocalAuthentication framework. Developer can easily authenticate users biometrically or with a passphrase.
+
+Some awesome features of NimbleLocalAuthentication:
+
+- Support enable or disable the biometric feature on the application.
+- Easy to localized strings with biometric screens.
+
+You can check out more about the SDK in the document [WIP]
+
+## Sample projects
+
+We have a sample project in the repository. To use it, download the repo, run `pod install` in Example folder to download the required libraries and open [Example.xcworkspace](https://github.com/nimblehq/local-authentication-ios/tree/main/Example/Example.xcworkspace).
+
+## Installation
+
+For `NimbleLocalAuthentication`, use the following entry in your Podfile:
+
+```rb
+pod 'NimbleLocalAuthentication', '~> 1.0'
+```
+
+Then run `pod install`
+
+## Usage
+
+Using `NimbleLocalAuthentication` is really simple. You can access an API like this:
+
+```swift
+let biometryService: BiometryService = NimbleLocalAuthenticatior()
+
+biometryService.authenticate { [weak self] result in
+  DispatchQueue.main.async {
+    switch result {
+    case .success:
+      // do something after authenticate successfully
+    case .failure(let error):
+      // hackers are trying to authenticate :D
+    }
+  }
+}
+```
+
+## License
+
+This project is Copyright (c) 2014-2021 Nimble. It is free software,
+and may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: /LICENSE
+
+## About
+
+![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+
+This project is maintained and funded by Nimble.
+
+We love open source and do our part in sharing our work with the community!
+See [our other projects][community] or [hire our team][hire] to help build your product.
+
+[community]: https://github.com/nimblehq
+[hire]: https://nimblehq.co/

--- a/Sources/Classes/BiometryError.swift
+++ b/Sources/Classes/BiometryError.swift
@@ -18,6 +18,6 @@ public enum BiometryError: LocalizedError, Equatable {
   /// Authentication could not start because biometry is not available on the device.
   case notAvailable
 
-  /// Authentication could not start because other reasons.
+  /// Authentication could not start because of other reasons.
   case failed
 }

--- a/Sources/Classes/BiometryError.swift
+++ b/Sources/Classes/BiometryError.swift
@@ -5,10 +5,19 @@
 //  Created by Su Van Ho on 15/1/21.
 //
 
+/// A type representing possible errors NimbleLocalAuthentication can throw.
 public enum BiometryError: LocalizedError, Equatable {
 
+  /// Authentication was not successful because there were too many failed biometry attempts and
+  /// biometry is now locked. Passcode is required to unlock biometry, e.g. evaluating
   case lockout
+
+  /// Authentication could not start because biometry has no enrolled identities.
   case notEnrolled
+
+  /// Authentication could not start because biometry is not available on the device.
   case notAvailable
+
+  /// Authentication could not start because other reasons.
   case failed
 }

--- a/Sources/Classes/BiometryService.swift
+++ b/Sources/Classes/BiometryService.swift
@@ -25,7 +25,7 @@ public protocol BiometryService: AnyObject {
   /// Cancel button title.
   var localizedCancelTitle: String? { get set }
 
-  /// Allows setting the default localized authentication reason on context.
+  /// Allows setting the default localized authentication reason to show to the user.
   var localizedReason: String { get set }
 
   /// Allows running authentication in non-interactive mode.

--- a/Sources/Classes/BiometryService.swift
+++ b/Sources/Classes/BiometryService.swift
@@ -7,10 +7,16 @@
 
 import LocalAuthentication
 
+/// The protocol used to define the specifications necessary for the SDK.
 public protocol BiometryService: AnyObject {
 
+  /// A boolean value stating whether the biometric feature is enabled.
   var isEnabled: Bool { get set }
+
+  /// A boolean value stating whether the biometric feature is available.
   var isAvailable: Bool { get }
+
+  /// A enum value stating
   var supportedType: BiometryType { get }
   var localizedFallbackTitle: String? { get set }
   var localizedCancelTitle: String? { get set }

--- a/Sources/Classes/BiometryService.swift
+++ b/Sources/Classes/BiometryService.swift
@@ -16,15 +16,50 @@ public protocol BiometryService: AnyObject {
   /// A boolean value stating whether the biometric feature is available.
   var isAvailable: Bool { get }
 
-  /// A enum value stating
+  /// Indicates the type of the biometry supported by the device.
   var supportedType: BiometryType { get }
+
+  /// Fallback button title.
   var localizedFallbackTitle: String? { get set }
+
+  /// Cancel button title.
   var localizedCancelTitle: String? { get set }
+
+  /// Allows setting the default localized authentication reason on context.
   var localizedReason: String { get set }
+
+  /// Allows running authentication in non-interactive mode.
   var interactionNotAllowed: Bool { get set }
 
+  /// Authenticates the user when using the application.
+  ///
+  /// @param completion Completeion block that is executed when authentication finishes.
+  ///              success Completion parameter that is success if the authentication has been authenticate successfully.
+  ///              failure Completion parameter that is failed if the authentication has been authenticate failed.
+  ///                    contains error information about the authentication failure.
+  ///
+  /// @see BiometryError
   func authenticate(completion: @escaping (BiometryResult) -> Void)
+
+  /// Invalidates the biometry service
   func invalidate()
+
+  /// Credential provided by application
+  ///
+  /// Sets a credential to this service
+  ///
+  /// @param credential Credential to be used with subsequent calls. Setting this parameter to nil will remove
+  ///                   any existing credential of the specified type.
+  ///
+  /// @param type CredentialType of the provided credential.
+  ///
+  /// @return YES if the credential was set successfully, NO otherwise.
   func setCredential(_ credential: Data?, type: CredentialType) -> Bool
+
+  /// Reveals if credential was set with this context.
+  ///
+  /// @param type CredentialType of credential we are asking for.
+  ///
+  /// @return YES on success, NO otherwise.
   func isCredentialSet(_ type: CredentialType) -> Bool
 }

--- a/Sources/Classes/BiometryService.swift
+++ b/Sources/Classes/BiometryService.swift
@@ -7,7 +7,7 @@
 
 import LocalAuthentication
 
-/// The protocol used to define the specifications necessary for the SDK.
+/// The protocol used to define the necessary specifications for the SDK.
 public protocol BiometryService: AnyObject {
 
   /// A boolean value stating whether the biometric feature is enabled.
@@ -34,9 +34,9 @@ public protocol BiometryService: AnyObject {
   /// Authenticates the user when using the application.
   ///
   /// @param completion Completeion block that is executed when authentication finishes.
-  ///              success Completion parameter that is success if the authentication has been authenticate successfully.
+  ///              success Completion parameter that is success if the authentication has been excuted successfully.
   ///              failure Completion parameter that is failed if the authentication has been authenticate failed.
-  ///                    contains error information about the authentication failure.
+  ///                    contains error information about the authentication's failure.
   ///
   /// @see BiometryError
   func authenticate(completion: @escaping (BiometryResult) -> Void)


### PR DESCRIPTION
### Why?

NimbleLocalAuthentication is an iOS SDK, we should add a document for that

### Insights

- [x] Create API documents in code
- [x] Update content for README.md